### PR TITLE
xrx state machine initial draft

### DIFF
--- a/shopify-app/docker-compose.yaml
+++ b/shopify-app/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
 
   xrx-reasoning:
     container_name: xrx-reasoning
+    stdin_open: true
+    tty: true
     build:
       context: .
       dockerfile: reasoning/Dockerfile

--- a/shopify-app/reasoning/app/agent/flows.yaml
+++ b/shopify-app/reasoning/app/agent/flows.yaml
@@ -1,0 +1,35 @@
+flows:
+  query:
+    initial: true
+    description: "In this flow you should figure out which of the other flows the user wants to enter into. This flow should be selected when you have fulfilled the objective of a state, but there are no outgoing transitions to other states."
+    states:
+      query:
+        initial: true
+        description: "Determine whether the user wants to buy something from the store or submit something to the store."
+
+  buying:
+    description: "In this flow your task is to help the user select and purchase an item from the store."
+    states:
+      productDetails:
+        initial: true
+        description: "In this state you should ask the user for the details of the product they want to purchase."
+        transitions: ["addOnSuggestions", "confirmation"]
+      addOnSuggestions:
+        description: "In this state you should suggest additional products that the user might want to purchase based on the product they have selected, if appropriate."
+        transitions: ["confirmation"] 
+      confirmation:
+        description: "In this state you should confirm with the user that they have selected the product and that they want to proceed with the purchase."
+        transitions: ["checkout"]
+      checkout:
+        description: "In this state you should ask the user for their payment details so that you can process their purchase."
+      
+  submitting: 
+    description: "In this flow your task is to allow the user to submit a new item to be listed in the store's catalog. You should collect the appropriate details from the user and then update the store's catalog as necessary." 
+    states:
+      productDetails:
+        initial: true
+        description: "In this state you should ask the user for the details of the product they want to submit to the store's catalog."
+        transitions: ["contactDetails"]
+      contactDetails:
+        description: "In this state you should ask the user for their contact details so that you can get in touch with them to confirm the submission of their product."
+              

--- a/shopify-app/reasoning/app/agent/graph/main.py
+++ b/shopify-app/reasoning/app/agent/graph/main.py
@@ -2,6 +2,7 @@ import asyncio
 from .base import *
 from .nodes.routing import Routing
 from .nodes.choose_tool import ChooseTool
+from .nodes.transition_state import TransitionState
 from .nodes.customer_response import CustomerResponse
 from .nodes.convert_natural_language import ConvertNaturalLanguage
 from .nodes.identify_tool_params import IdentifyToolParams
@@ -26,7 +27,7 @@ Parameters: {parameters}
 <awaiting next steps>
 '''
 
-async def agent_graph(messages, task_id='', action={}, memory=None):
+async def agent_graph(messages, task_id='', action={}, memory=None, state_machine=None):
 
     # define all nodes
     node_routing = Routing('Routing', {})
@@ -34,6 +35,7 @@ async def agent_graph(messages, task_id='', action={}, memory=None):
     node_convert_natural_language = ConvertNaturalLanguage('ConvertNaturalLanguage', {})
     node_identify_tool_params = IdentifyToolParams('IdentifyToolParams', {})
     node_execute_tool = ExecuteTool('ExecuteTool', {})
+    node_transition_state = TransitionState('TransitionState', {})
     node_customer_response = CustomerResponse('CustomerResponse', {})
     node_widget = Widget('Widget', {})
     node_task_description = TaskDescriptionResponse('TaskDescriptionResponse', {})
@@ -46,6 +48,7 @@ async def agent_graph(messages, task_id='', action={}, memory=None):
     graph.add_node(node_convert_natural_language)
     graph.add_node(node_identify_tool_params)
     graph.add_node(node_execute_tool)
+    graph.add_node(node_transition_state)
     graph.add_node(node_widget)
     graph.add_node(node_task_description)
 
@@ -72,6 +75,10 @@ async def agent_graph(messages, task_id='', action={}, memory=None):
         input_dict['tool'] = action['details']['tool']
         input_dict['parameters'] = action['details']['parameters']
     logger.info(f"Starting traversal at node: {starting_node}")
+
+    if not input_dict['memory']:
+        input_dict['memory'] = {}
+    input_dict['memory']['stateMachine'] = state_machine
 
     # start the graph traversal
     try:

--- a/shopify-app/reasoning/app/agent/graph/nodes/convert_natural_language.py
+++ b/shopify-app/reasoning/app/agent/graph/nodes/convert_natural_language.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import json
 import asyncio
-from agent_framework import observability_decorator, initialize_async_llm_client, json_fixer
+from agent_framework import observability_decorator, initialize_async_llm_client, json_fixer, StateMachine
 from agent.config import tools_dict, tool_param_desc
 import openai
 
@@ -102,6 +102,8 @@ class ConvertNaturalLanguage(Node):
             # add the conversation to the system prompt
             single_system_prompt = single_system_prompt.replace('{conversation}', conversation)
 
+            single_system_prompt = single_system_prompt.replace('{flow_and_state_info}', StateMachine.getStateMachinePrompt(input['memory']))
+            
             # create the messages format
             input_messages = [
                 {

--- a/shopify-app/reasoning/app/agent/graph/nodes/identify_tool_params.py
+++ b/shopify-app/reasoning/app/agent/graph/nodes/identify_tool_params.py
@@ -3,7 +3,7 @@ import os
 import logging
 import json
 import asyncio
-from agent_framework import observability_decorator, initialize_async_llm_client, json_fixer
+from agent_framework import observability_decorator, initialize_async_llm_client, json_fixer, StateMachine
 from agent.config import tools_dict, tool_param_desc
 import openai
 from pprint import pformat
@@ -30,6 +30,10 @@ You an expert at identifying and mapping parameters from a conversation and memo
 
 ## Conversation so far:
 {conversation}
+
+## Flow and State Information
+
+{flow_and_state_info}
 
 ## Output Format
 You must return a perfectly formatted JSON object which can be serialized with the following keys:
@@ -87,6 +91,13 @@ class IdentifyToolParams(Node):
 
                 # add the conversation to the system prompt
                 single_system_prompt = single_system_prompt.replace('{conversation}', conversation)
+
+                # add the state machine prompt to the system prompt
+                single_system_prompt = single_system_prompt.replace('{flow_and_state_info}', StateMachine.getStateMachinePrompt(input['memory']))
+
+                # add state machine tool info to the system prompt
+                single_system_prompt = single_system_prompt.replace('{state_machine_tools}', StateMachine.getStateMachineTransitionCalls(input['memory']))
+
                 logger.info(f"single_system_prompt: {single_system_prompt}")
 
                 # create the messages format

--- a/shopify-app/reasoning/app/agent/graph/nodes/transition_state.py
+++ b/shopify-app/reasoning/app/agent/graph/nodes/transition_state.py
@@ -18,16 +18,15 @@ LLM_CLIENT = initialize_async_llm_client()
 LLM_MODEL_ID = os.environ.get('LLM_MODEL_ID', '')
 
 SYSTEM_PROMPT = '''\
-You are an expert at deciding which tool to use to generate a response to the customer from the assistant. 
-If the tool output is already in the conversation, don't use the tool again.
-Keep track of previous tool calls and their results. If a tool call fails or produces unexpected results, do not repeat the same call without modification. Instead, analyze the error, report it to the user, and suggest an alternative action.
+You are an expert at deciding which state machine state or flow to transition to next, given the current state, the conversation history, and \
+the descriptions of the potential next states and flows. Only choose a state or flow if it appears in the list below. If you are transitioning \
+between states, the name of your transition should begin with 'state_transition_'. If you are transitioning between flows, the name of your \
+transition should begin with 'flow_transition_'.
+
 Maintain awareness of the full conversation history. Use this context to avoid repeating information or asking for details that have already been provided. Regularly summarize the current state of the order to ensure consistency.
 
-## Tools
-You have access to the following tools. Choose these tools only if the objective of the current state has not been met.
-
-{tools}
-
+## Potential Next States and Flows
+{state_machine_transitions}
 
 ## Historical Conversation
 
@@ -42,68 +41,50 @@ Here is the conversation so far:
 ## Output Format
 You must return a perfectly formatted JSON object which can be serialized with the following keys:
 - 'reason': a string explaining which tool is the correct tool for the situation.
-- 'tool': a string representing the tool to use.
+- 'tool': a string representing the transition to make. This should be strictly limitited to the transitions listed under 'Potential Next States and Flows'.
 
 The 'reason' string should follow a pattern like below:
-"The previous tool calls accomplished <diagnosis of previous tool calls here>. \
-My current objective as defined by the state of the state machine is <current objective>. \
-Has this objective been met? <true or false>. \
-Is the user's question related to the current objective? <true or false>. \
-Based on these previous actions, the correct tool to call is <tool or state machine tool name here>. \
-When I call this tool, I will use the following parameters: <description of tool parameter inputs here, or blank if state machine tool>"
+"My current objective as defined by the state of the state machine is <current objective>. \
+The objective of the current state has been met. Based on the context of my conversation with the customer, \
+I am choosing to transition to <state or flow name here>. \"
 
 Only use the state of the state machine listed in Flow and State Information to derive your objective; do not infer it on your own.
 
-If it is clear that a tool should not be called in this situation, simply state why in the 'reason' key \
+If it is clear that a transition shoudl not be made in this situation, simply state why in the 'reason' key \
 and place a blank string "" in the 'tool' key.
 
 ## Rules
-- Never assume an id input if it is not provided in the context or previous tool calls.
-- Always use the exact values returned by the previous tools. Do not modify or create new values.
 - Provide all information in the JSON object. Any other text is strictly forbidden.
-- If you're unsure about any information, use the appropriate tool to verify rather than making assumptions.
-- Do not choose tools that will not move you directly towards the objective of the current state.
-'''.replace('{tools}', tools_desc)
-
-TOOL_CACHE_PROMPT = '''
-assistant:
-### Tools Used Before Responding to Customer
-
-{tool_output_cache}
 '''
 
-class ChooseTool(Node):
+
+class TransitionState(Node):
     def __init__(self, name, attributes):
         super().__init__(name, attributes)
         self.llm_client = LLM_CLIENT
         self.llm_model_id = LLM_MODEL_ID
 
-    @observability_decorator('ChooseTool')
+    @observability_decorator('TransitionState')
     async def process(self, messages: list, input: dict):
         try:
-            logger.info(f"ChooseTool processing messages: {messages}")
-            logger.info(f"ChooseTool processing input: {pformat(input, indent=2, width=100)}")
+            logger.info(f"TransitionState processing messages: {messages}")
+            logger.info(f"TransitionState processing input: {pformat(input, indent=2, width=100)}")
             
             # make a  copy of the system prompt
             single_system_prompt = SYSTEM_PROMPT
 
-            # retrieve all tool calls which have been made and make the string if there are any
-            tool_output_cache = input.get('memory', {}).get('tool-output-cache', [])
-
             # create the conversation variable
             conversation = ''.join([f"{i['role']}: {i['content']}\n" for i in messages])
+
+            # add the conversation to the system prompt
+            single_system_prompt = single_system_prompt.replace('{conversation}', conversation)
 
             # add the state machine prompt to the system prompt
             single_system_prompt = single_system_prompt.replace('{flow_and_state_info}', StateMachine.getStateMachinePrompt(input['memory']))
 
-            # add tool call cache to the conversation if it exists
-            if len(tool_output_cache) > 0:
-                tool_output_cache_str = ''.join([f"* {i['tool']}: {i['description']}\n" for i in tool_output_cache])
-                single_tool_cache_prompt = TOOL_CACHE_PROMPT.replace('{tool_output_cache}', tool_output_cache_str)
-                conversation += single_tool_cache_prompt
+            # add state machine tool info to the system prompt
+            single_system_prompt = single_system_prompt.replace('{state_machine_transitions}', StateMachine.getStateMachineTransitionCalls(input['memory']))
 
-            # add the conversation to the system prompt
-            single_system_prompt = single_system_prompt.replace('{conversation}', conversation)
 
             # create the messages format
             input_messages = [
@@ -118,7 +99,7 @@ class ChooseTool(Node):
             })
 
             # call the LLM
-            logger.debug(f"ChooseTool input messages:\n{pformat(input_messages, indent=2, width=100)}")
+            logger.debug(f"TransitionState input messages:\n{pformat(input_messages, indent=2, width=100)}")
             try:
                 response = await self.llm_client.chat.completions.create(
                     model=self.llm_model_id,
@@ -136,19 +117,20 @@ class ChooseTool(Node):
                     tool_output = await json_fixer(e.response.json()['error']['failed_generation'])
                 else:
                     raise e
-            logger.info(f"ChooseTool tool_output: {tool_output}")
+            logger.info(f"TransitionState tool_output: {tool_output}")
 
             # send the data back to the endpoint
             await asyncio.sleep(0) 
+
             yield {
                 'node': self.id,
                 'reason': tool_output['reason'],
                 'output': tool_output['tool'],
                 'memory': input.get('memory', {})
             }
-            logger.info("ChooseTool finished processing")
+            logger.info("TransitionState finished processing")
         except Exception as e:
-            logger.exception(f"An error occurred in ChooseTool")
+            logger.exception(f"An error occurred in TransitionState")
             raise e
 
     async def get_successors(self, result: dict):
@@ -156,14 +138,10 @@ class ChooseTool(Node):
         tool = result.get('output', '')
         reason = result.get('reason', '')
         
-        # format the tool if the model outputs a tool with parameters
-        if '(' in tool:
-            tool = tool.split('(')[0]
-
         if tool != "":
-            successors.append(("IdentifyToolParams", {
-                'tool': tool, 
-                'reason': reason,
+            successors.append(("ExecuteTool", {
+                'tool': tool,
+                'parameters': {},
                 'memory': result.get('memory', {})
             }))
         else:

--- a/shopify-app/reasoning/app/agent/sample_conversations/basic1.txt
+++ b/shopify-app/reasoning/app/agent/sample_conversations/basic1.txt
@@ -1,0 +1,1037 @@
+(myenv) mprast@Matthews-MacBook-Pro test % python interactive_test.py
+Interactive Shopify Agent Test. Type 'quit' to exit.
+================================================================================
+Customer: hello
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user greeted the assistant. My current objective as defined by the state of the state machine is to determine which flow the user should enter into 
+next. Is the user's question related to the current objective? false. Has the objective of the current state been met? false. The previous tool calls accomplished nothing. Based on these previous tool 
+calls and all available information, I am choosing to ask the user about their intention."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nHow can I help you today?'}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'How can I help you today?',
+    'reason': "To address the customer's greeting. The customer has initiated a greeting without a request. The customer is able to see the initial app screen. My current objective as defined by the state
+of the state machine is to determine which flow the user should enter into next. Is the user's question related to the current objective? false. Has the objective of the current state been met? false. The
+tool outputs are missing information to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: i'd like to buy a blue snowboard
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user greeted and expressed their desire to buy a blue snowboard. My current objective as defined by the state of the state machine is to determine 
+which flow the user should enter into next. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls accomplished 
+nothing. Based on these previous tool calls and all available information, I am choosing to transition to the buying flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me find that blue snowboard for you.',
+    'reason': "The customer has requested a specific product, and I'm checking availability."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_buying',
+    'reason': 'My current objective as defined by the state of the state machine is to Determine which flow the user should enter into next. The objective of the current state has been met. Based on the 
+context of my conversation with the customer, I am choosing to transition to buying.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'buying'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: We are now in the process of buying a product, specifically a blue snowboard, following the customer's 
+request. No specific products, orders, or carts have been identified yet.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "We are now in the process of buying a product, specifically a blue snowboard, following the customer's request. No specific products, orders, or carts have been identified yet.",
+    'reason': "The tool output indicates a transition to the 'buying' flow. This is in response to the customer's request to buy a blue snowboard."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: We are now in the process of buying a product, specifically a blue snowboard, following the customer's 
+request. No specific products, orders, or carts have been identified yet.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed that the user initiated a conversation with a general greeting and then specified a product they want to purchase. My current objective as defined by the 
+state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? True. Has the objective of the current state 
+been met? False. The previous tool calls accomplished nothing. Based on these previous tool calls and all available information, I am choosing to respond to the customer with a question to elicit more 
+information about the product they want to purchase."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: We are now in the process of buying a product, specifically a blue snowboard, following the customer's 
+request. No specific products, orders, or carts have been identified yet.\n\n\n### Audio Response to Customer\n\nWhat size and style of blue snowboard are you looking for?"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What size and style of blue snowboard are you looking for?',
+    'reason': "To address the customer's inquiry about buying a blue snowboard. The information provided by the tools tells me that we are in the process of buying a product, specifically a blue 
+snowboard, following the customer's request. The customer is able to see that we have transitioned to the buying flow. My current objective as defined by the state of the state machine is to ask the user 
+for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing 
+details about the specific blue snowboard the customer wants to purchase. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: just an entry-level one, I don't have a specific idea of which one would be best
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user greeted and indicated a desire to purchase a blue snowboard. My current objective as defined by the state of the state machine is to ask the user
+for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls 
+accomplished nothing. Based on these previous tool calls and all available information, I am choosing to ask for more details about the snowboard."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nLet me show you some options for our blue entry-level snowboards. Take a look below.'}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'Let me show you some options for our blue entry-level snowboards. Take a look below.',
+    'reason': "To address the customer's inquiry about an entry-level blue snowboard The information provided by the tools tells me we are now in the process of buying a product, specifically a blue 
+snowboard, following the customer's request. The customer is able to see no specific output. My current objective as defined by the state of the state machine is to ask the user for the details of the 
+product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing specific product details 
+to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: ok
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'call-tool',
+    'reason': "The historical conversation showed the user wants to buy a blue snowboard. My current objective as defined by the state of the state machine is to ask the user for the details of the 
+product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls accomplished nothing. Based on
+these previous tool calls and all available information, I am choosing to call the get_products() tool to get a list of blue snowboards that match the user's request."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me find the best one for you.',
+    'reason': "The customer has been presented with options for blue entry-level snowboards and is likely considering their choices. This response acknowledges the customer's current situation and implies
+that I'm going to help them with the next step."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ChooseTool',
+    'output': 'get_products',
+    'reason': "The previous tool calls did not accomplish getting product details. My current objective as defined by the state of the state machine is to ask the user for the details of the product they 
+want to purchase. Has this objective been met? False. Is the user's question related to the current objective? True. Based on these previous actions, the correct tool to call is get_products(). When I 
+call this tool, I will use the following parameters: No parameters are required for this tool."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'IdentifyToolParams',
+    'output': {},
+    'reason': ''
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': {
+        '9669071307065': {'product_id': 9669071307065, 'product_title': 'Gift Card', 'options': [{'option_title': 'Denominations'}]},
+        '9669071569209': {'product_id': 9669071569209, 'product_title': 'Selling Plans Ski Wax', 'options': [{'option_title': 'Title'}]},
+        '9669071438137': {'product_id': 9669071438137, 'product_title': 'The 3p Fulfilled Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071110457': {'product_id': 9669071110457, 'product_title': 'The Collection Snowboard: Hydrogen', 'options': [{'option_title': 'Title'}]},
+        '9669071634745': {'product_id': 9669071634745, 'product_title': 'The Collection Snowboard: Liquid', 'options': [{'option_title': 'Title'}]},
+        '9669071536441': {'product_id': 9669071536441, 'product_title': 'The Collection Snowboard: Oxygen', 'options': [{'option_title': 'Title'}]},
+        '9669071241529': {'product_id': 9669071241529, 'product_title': 'The Compare at Price Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071143225': {'product_id': 9669071143225, 'product_title': 'The Complete Snowboard', 'options': [{'option_title': 'Color'}]},
+        '9669071077689': {'product_id': 9669071077689, 'product_title': 'The Hidden Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071372601': {'product_id': 9669071372601, 'product_title': 'The Inventory Not Tracked Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071012153': {'product_id': 9669071012153, 'product_title': 'The Minimal Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071405369': {'product_id': 9669071405369, 'product_title': 'The Multi-location Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071470905': {'product_id': 9669071470905, 'product_title': 'The Multi-managed Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071274297': {'product_id': 9669071274297, 'product_title': 'The Out of Stock Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071044921': {'product_id': 9669071044921, 'product_title': 'The Videographer Snowboard', 'options': [{'option_title': 'Title'}]}
+    },
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Widget',
+    'output': {
+        'type': 'shopify-product-list',
+        'details': '{"9669071307065": {"product_id": 9669071307065, "product_title": "Gift Card", "options": [{"option_title": "Denominations"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/gift_card.png?v=1727830795"}, "9669071569209": {"product_id": 9669071569209, "product_title": "Selling Plans Ski Wax", "options": [{"option_title": 
+"Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_wax.png?v=1727830798"}, "9669071438137": {"product_id": 9669071438137, "product_title": "The 3p Fulfilled 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b9e0da7f-db89-4d41-83f0-7f417b02831d.jpg?v=1727830796"}, 
+"9669071110457": {"product_id": 9669071110457, "product_title": "The Collection Snowboard: Hydrogen", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_0a40b01b-5021-48c1-80d1-aa8ab4876d3d.jpg?v=1727830794"}, "9669071634745": {"product_id": 9669071634745, "product_title": "The Collection 
+Snowboard: Liquid", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b13ad453-477c-4ed1-9b43-81f3345adfd6.jpg?v=1727830798"}, 
+"9669071536441": {"product_id": 9669071536441, "product_title": "The Collection Snowboard: Oxygen", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_d624f226-0a89-4fe1-b333-0d1548b43c06.jpg?v=1727830796"}, "9669071241529": {"product_id": 9669071241529, "product_title": "The Compare at Price 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_sky.png?v=1727830795"}, "9669071143225": {"product_id": 
+9669071143225, "product_title": "The Complete Snowboard", "options": [{"option_title": "Color"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1727830794"}, "9669071077689": {"product_id": 9669071077689, "product_title": "The Hidden 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_c8ff0b5d-c712-429a-be00-b29bd55cbc9d.jpg?v=1727830794"}, 
+"9669071372601": {"product_id": 9669071372601, "product_title": "The Inventory Not Tracked Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_purple_hydrogen.png?v=1727830795"}, "9669071012153": {"product_id": 9669071012153, "product_title": "The Minimal Snowboard", "options": 
+[{"option_title": "Title"}]}, "9669071405369": {"product_id": 9669071405369, "product_title": "The Multi-location Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_0a4e9096-021a-4c1e-8750-24b233166a12.jpg?v=1727830795"}, "9669071470905": {"product_id": 9669071470905, "product_title": "The Multi-managed 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_9129b69a-0c7b-4f66-b6cf-c4222f18028a.jpg?v=1727830796"}, 
+"9669071274297": {"product_id": 9669071274297, "product_title": "The Out of Stock Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_f44a9605-cd62-464d-b095-d45cdaa0d0d7.jpg?v=1727830795"}, "9669071044921": {"product_id": 9669071044921, "product_title": "The Videographer 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main.jpg?v=1727830795"}}',
+        'available-tools': [{'tool': 'get_product_details', 'arguments': ['product_id']}]
+    },
+    'reason': 'hard coded widget creation'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input {} returned a list of products including 9669071307065: Gift Card, 9669071569209: 
+Selling Plans Ski Wax, 9669071438137: The 3p Fulfilled Snowboard, 9669071110457: The Collection Snowboard: Hydrogen, 9669071634745: The Collection Snowboard: Liquid, 9669071536441: The Collection 
+Snowboard: Oxygen, 9669071241529: The Compare at Price Snowboard, 9669071143225: The Complete Snowboard, 9669071077689: The Hidden Snowboard, 9669071372601: The Inventory Not Tracked Snowboard, 
+9669071012153: The Minimal Snowboard, 9669071405369: The Multi-location Snowboard, 9669071470905: The Multi-managed Snowboard, 9669071274297: The Out of Stock Snowboard, and 9669071044921: The 
+Videographer Snowboard. Relevant information to the conversation might include product IDs and titles that match the customer's request for a blue snowboard.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling get_products with input {} returned a list of products including 9669071307065: Gift Card, 9669071569209: Selling Plans Ski Wax, 9669071438137: The 3p Fulfilled Snowboard, 
+9669071110457: The Collection Snowboard: Hydrogen, 9669071634745: The Collection Snowboard: Liquid, 9669071536441: The Collection Snowboard: Oxygen, 9669071241529: The Compare at Price Snowboard, 
+9669071143225: The Complete Snowboard, 9669071077689: The Hidden Snowboard, 9669071372601: The Inventory Not Tracked Snowboard, 9669071012153: The Minimal Snowboard, 9669071405369: The Multi-location 
+Snowboard, 9669071470905: The Multi-managed Snowboard, 9669071274297: The Out of Stock Snowboard, and 9669071044921: The Videographer Snowboard. Relevant information to the conversation might include 
+product IDs and titles that match the customer's request for a blue snowboard.",
+    'reason': 'The tool call result provides a list of products, including their IDs, which is critical for downstream tasks. Since the conversation is about buying a blue snowboard, relevant information 
+includes the product IDs and titles.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input {} returned a list of products including 9669071307065: Gift Card, 9669071569209: 
+Selling Plans Ski Wax, 9669071438137: The 3p Fulfilled Snowboard, 9669071110457: The Collection Snowboard: Hydrogen, 9669071634745: The Collection Snowboard: Liquid, 9669071536441: The Collection 
+Snowboard: Oxygen, 9669071241529: The Compare at Price Snowboard, 9669071143225: The Complete Snowboard, 9669071077689: The Hidden Snowboard, 9669071372601: The Inventory Not Tracked Snowboard, 
+9669071012153: The Minimal Snowboard, 9669071405369: The Multi-location Snowboard, 9669071470905: The Multi-managed Snowboard, 9669071274297: The Out of Stock Snowboard, and 9669071044921: The 
+Videographer Snowboard. Relevant information to the conversation might include product IDs and titles that match the customer's request for a blue snowboard.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed that the customer is looking for a blue snowboard and we are now in the process of buying a product following the customer's request. My current objective
+as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of 
+the current state been met? false. The previous tool calls accomplished getting a list of products from get_products. Based on these previous tool calls and all available information, I am choosing to 
+respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input {} returned a list of products including 9669071307065: Gift Card, 9669071569209: 
+Selling Plans Ski Wax, 9669071438137: The 3p Fulfilled Snowboard, 9669071110457: The Collection Snowboard: Hydrogen, 9669071634745: The Collection Snowboard: Liquid, 9669071536441: The Collection 
+Snowboard: Oxygen, 9669071241529: The Compare at Price Snowboard, 9669071143225: The Complete Snowboard, 9669071077689: The Hidden Snowboard, 9669071372601: The Inventory Not Tracked Snowboard, 
+9669071012153: The Minimal Snowboard, 9669071405369: The Multi-location Snowboard, 9669071470905: The Multi-managed Snowboard, 9669071274297: The Out of Stock Snowboard, and 9669071044921: The 
+Videographer Snowboard. Relevant information to the conversation might include product IDs and titles that match the customer's request for a blue snowboard.\n\n\n### Audio Response to Customer\n\nWhich 
+one of these blue snowboards looks most appealing to you?"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'Which one of these blue snowboards looks most appealing to you?',
+    'reason': "To address the customer's inquiry about buying a blue snowboard. The information provided by the tools tells me that a list of products has been retrieved. The customer is able to see the 
+options. My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective?
+true. Has the objective of the current state been met? false. The tool outputs are missing the specific product the customer wants to purchase to answer the customer's inquiry. Based on the tool outputs, 
+I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: the first one!
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'call-tool',
+    'reason': "The historical conversation showed that the user wants to purchase a blue snowboard. My current objective as defined by the state of the state machine is to ask the user for the details of 
+the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The previous tool calls accomplished getting a list
+of blue snowboards. Based on these previous tool calls and all available information, I am choosing to get the product details for the selected snowboard."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me grab the details on that one.',
+    'reason': "The customer has selected a product and I'm now checking its details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ChooseTool',
+    'output': 'get_product_details',
+    'reason': "The previous tool calls accomplished getting a list of products. My current objective as defined by the state of the state machine is to ask the user for the details of the product they 
+want to purchase. Has this objective been met? false. Is the user's question related to the current objective? true. Based on these previous actions, the correct tool to call is get_product_details. When 
+I call this tool, I will use the following parameters: product_id=9669071438137."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'IdentifyToolParams',
+    'output': {'product_id': 9669071438137},
+    'reason': 'Based on the conversation, the user has selected a product with ID 9669071438137. This ID is used to get the product details.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': {
+        'product_id': 9669071438137,
+        'product_title': 'The 3p Fulfilled Snowboard',
+        'product_variants': [{'variant_id': 49997746569529, 'variant_name': 'Default Title', 'price': '2629.95', 'product_variant_sku': 'sku-hosted-1'}]
+    },
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Widget',
+    'output': {
+        'type': 'shopify-product-details',
+        'details': '{"product_id": 9669071438137, "product_title": "The 3p Fulfilled Snowboard", "product_variants": [{"variant_id": 49997746569529, "variant_name": "Default Title", "price": "2629.95", 
+"product_variant_sku": "sku-hosted-1", "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b9e0da7f-db89-4d41-83f0-7f417b02831d.jpg?v=1727830796"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b9e0da7f-db89-4d41-83f0-7f417b02831d.jpg?v=1727830796"}',
+        'available-tools': [{'tool': 'add_item_to_cart', 'arguments': ['variant_id']}]
+    },
+    'reason': 'hard coded widget creation'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': 'Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled Snowboard with product ID 9669071438137, variant ID 49997746569529 named 
+Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might include the product ID and variant details for the selected blue snowboard.',
+    'reason': 'Describing the result of calling get_product_details with the selected product ID.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'call-tool',
+    'reason': "The historical conversation showed the user wants to buy a blue snowboard. My current objective as defined by the state of the state machine is to ask the user for the details of the 
+product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The previous tool calls accomplished getting product 
+details for the selected blue snowboard. Based on these previous tool calls and all available information, I am choosing to add the selected product to the cart."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ChooseTool',
+    'output': 'add_item_to_cart',
+    'reason': "The previous tool calls accomplished getting product details. My current objective as defined by the state of the state machine is to help the user select and purchase an item from the 
+store. Has this objective been met? False. Is the user's question related to the current objective? True. Based on these previous actions, the correct tool to call is add_item_to_cart. When I call this 
+tool, I will use the following parameters: variant_id from product details and quantity."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'IdentifyToolParams',
+    'output': {'variant_id': 49997746569529, 'quantity': 1},
+    'reason': 'Based on the conversation, the user has selected a product and we need to add it to the cart. The variant_id is obtained from the product details and the quantity is assumed to be 1 for 
+now.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ExecuteTool',
+    'output': {
+        'cart_summary': {
+            'total_price': '2629.95',
+            'line_items': [
+                {
+                    'name': 'The 3p Fulfilled Snowboard',
+                    'quantity': 1,
+                    'price': '2629.95',
+                    'variant_id': 49997746569529,
+                    'product_id': 9669071438137,
+                    'item_variant_sku': 'sku-hosted-1',
+                    'variant_title': None
+                }
+            ]
+        }
+    },
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Widget',
+    'output': {
+        'type': 'shopify-cart-summary',
+        'details': '{"cart_summary": {"total_price": "2629.95", "line_items": [{"name": "The 3p Fulfilled Snowboard", "quantity": 1, "price": "2629.95", "variant_id": 49997746569529, "product_id": 
+9669071438137, "item_variant_sku": "sku-hosted-1", "variant_title": null, "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b9e0da7f-db89-4d41-83f0-7f417b02831d.jpg?v=1727830796"}]}}',
+        'available-tools': [{'tool': 'submit_cart_for_order', 'arguments': []}]
+    },
+    'reason': 'hard coded widget creation'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ConvertNaturalLanguage',
+    'output': 'Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard 
+with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. Relevant information to the conversation might include the variant and product IDs 
+as well as the cart summary.',
+    'reason': 'The tool output was converted into a natural language description that includes all relevant IDs and information.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user is buying a blue snowboard. My current objective as defined by the state of the state machine is to help the user select and purchase an item 
+from the store. Is the user's question related to the current objective? True. Has the objective of the current state been met? True. The previous tool calls accomplished the retrieval of product details 
+and adding the product to the cart. Based on these previous tool calls and all available information, I am choosing to transition to the confirmation state because the user has selected a product and 
+added it to their cart."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'TransitionState',
+    'output': 'state_transition_addOnSuggestions',
+    'reason': 'My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. The objective of the current state has been met. 
+Based on the context of my conversation with the customer, I am choosing to transition to the addOnSuggestions state.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to state 'addOnSuggestions'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n* state_transition_addOnSuggestions: Transitioning to the addOnSuggestions state to provide
+additional suggestions related to the selected blue snowboard, The 3p Fulfilled Snowboard with product ID 9669071438137 and variant ID 49997746569529, currently in the cart with a total price of 
+2629.95.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ConvertNaturalLanguage',
+    'output': 'Transitioning to the addOnSuggestions state to provide additional suggestions related to the selected blue snowboard, The 3p Fulfilled Snowboard with product ID 9669071438137 and variant ID
+49997746569529, currently in the cart with a total price of 2629.95.',
+    'reason': 'Describing the result of the state_transition_addOnSuggestions tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n* state_transition_addOnSuggestions: Transitioning to the addOnSuggestions state to provide
+additional suggestions related to the selected blue snowboard, The 3p Fulfilled Snowboard with product ID 9669071438137 and variant ID 49997746569529, currently in the cart with a total price of 
+2629.95.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer is trying to purchase a blue snowboard. My current objective as defined by the state of the state machine is to suggest additional products 
+that the user might want to purchase based on the product they have selected. Is the user's question related to the current objective? False. Has the objective of the current state been met? False. The 
+previous tool calls accomplished getting product details for The 3p Fulfilled Snowboard and adding it to the cart. Based on these previous tool calls and all available information, I am choosing to 
+respond to the customer to explore additional products."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_product_details: Calling get_product_details with input product_id 9669071438137 returned product details for The 3p Fulfilled
+Snowboard with product ID 9669071438137, variant ID 49997746569529 named Default Title, priced at 2629.95, and having product variant SKU sku-hosted-1. Relevant information to the conversation might 
+include the product ID and variant details for the selected blue snowboard.\n* add_item_to_cart: Calling add_item_to_cart with input variant_id 49997746569529 and quantity 1 returned a cart summary with a
+total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1. 
+Relevant information to the conversation might include the variant and product IDs as well as the cart summary.\n* state_transition_addOnSuggestions: Transitioning to the addOnSuggestions state to provide
+additional suggestions related to the selected blue snowboard, The 3p Fulfilled Snowboard with product ID 9669071438137 and variant ID 49997746569529, currently in the cart with a total price of 
+2629.95.\n\n\n### Audio Response to Customer\n\nSince you're getting the blue snowboard, would you also like to get a snowboard boot and bindings to go with it?"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'CustomerResponse',
+    'output': "Since you're getting the blue snowboard, would you also like to get a snowboard boot and bindings to go with it?",
+    'reason': "To address the customer's selection of The 3p Fulfilled Snowboard, The information provided by the tools tells me that I have added the product to the cart. The customer is able to see the 
+cart summary below. My current objective as defined by the state of the state machine is to suggest additional products that the user might want to purchase based on the product they have selected. Is the
+user's question related to the current objective? True. Has the objective of the current state been met? False. The tool outputs are missing information about what additional products to suggest to the 
+customer. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: sure, that sounds great!
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer wants to buy a blue snowboard and has selected The 3p Fulfilled Snowboard. My current objective as defined by the state of the state machine 
+is to suggest additional products that the user might want to purchase based on the product they have selected, if appropriate. Is the user's question related to the current objective? True. Has the 
+objective of the current state been met? False. The previous tool calls accomplished getting product details and adding the selected product to the cart. Based on these previous tool calls and all 
+available information, I am choosing to suggest additional products that the user might want to purchase based on the product they have selected."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '\n\n### Audio Response to Customer\n\nLet me show you some options for snowboard boots and bindings that would pair well with your blue snowboard. Take a look below.'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'CustomerResponse',
+    'output': 'Let me show you some options for snowboard boots and bindings that would pair well with your blue snowboard. Take a look below.',
+    'reason': "To address the customer's confirmation of the additional products, The information provided by the tools tells me that we are currently in the addOnSuggestions state and the customer has 
+agreed to purchase additional products with their blue snowboard. The customer is able to see the updated cart summary. My current objective as defined by the state of the state machine is to provide 
+additional product suggestions. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The tool outputs are missing information about the 
+specific boot and bindings the customer wants. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: ok
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to buy a blue snowboard, and I helped the user select the product and add it to the cart. My current objective as defined by the state of 
+the state machine is to suggest additional products that the user might want to purchase based on the product they have selected. Is the user's question related to the current objective? True. Has the 
+objective of the current state been met? False. The previous tool calls accomplished getting the product details, adding the item to the cart, and suggesting additional products. Based on these previous 
+tool calls and all available information, I am choosing to respond to the customer to gather more information about the snowboard boots and bindings they want."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': "\n\n### Audio Response to Customer\n\nLet me know which boots and bindings you'd like to get with your blue snowboard."}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'CustomerResponse',
+    'output': "Let me know which boots and bindings you'd like to get with your blue snowboard.",
+    'reason': "To address the customer's desire to purchase a blue snowboard with boots and bindings, the information provided by the tools tells me that the customer has selected the blue snowboard, The 
+3p Fulfilled Snowboard, and I have suggested additional products, snowboard boots and bindings, that would pair well with it. The customer is able to see the suggested options. My current objective as 
+defined by the state of the state machine is to provide additional product suggestions based on the selected product. Is the user's question related to the current objective? true. Has the objective of 
+the current state been met? false. The tool outputs are missing information about the customer's selection of boots and bindings to complete the purchase. Based on the tool outputs, I will give the 
+customer a factually grounded response which says"
+}
+================================================================================
+Customer: the first one please
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the customer wants to buy a blue snowboard. My current objective as defined by the state of the state machine is to suggest additional products that the 
+user might want to purchase based on the product they have selected. Is the user's question related to the current objective? True. Has the objective of the current state been met? True. The previous tool
+calls accomplished getting product details, adding item to cart, and suggesting additional products. Based on these previous tool calls and all available information, I am choosing to transition to the 
+confirmation state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'TaskDescriptionResponse',
+    'output': "Just a sec, I'm putting everything together for you.",
+    'reason': "The customer has selected a snowboard and additional accessories. I'm preparing the order."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'TransitionState',
+    'output': 'state_transition_confirmation',
+    'reason': 'My current objective as defined by the state of the state machine is to suggest additional products that the user might want to purchase based on the product they have selected, if 
+appropriate. The objective of the current state has been met. Based on the context of my conversation with the customer, I am choosing to transition to the confirmation state.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to state 'confirmation'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ConvertNaturalLanguage',
+    'output': 'Calling state_transition_confirmation with input {} returned a transition to the confirmation state. Relevant information to the conversation might include the product ID 9669071438137, 
+variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 
+9669071438137, and item variant SKU sku-hosted-1.',
+    'reason': 'The output from the state_transition_confirmation tool is being described.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user wants to buy a blue snowboard and has selected one with variant ID 49997746569529. My current objective as defined by the state of the state 
+machine is to confirm with the user that they have selected the product and that they want to proceed with the purchase. Is the user's question related to the current objective? True. Has the objective of
+the current state been met? True. The previous tool calls accomplished getting product details and adding the item to the cart. Based on these previous tool calls and all available information, I am 
+choosing to transition to the next state and ask for payment details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'TransitionState',
+    'output': 'state_transition_checkout',
+    'reason': 'My current objective as defined by the state of the state machine is to confirm with the user that they have selected the product and that they want to proceed with the purchase. The 
+objective of the current state has been met. Based on the context of my conversation with the customer, I am choosing to transition to the checkout state.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to state 'checkout'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n* state_transition_checkout: Calling 
+state_transition_checkout with input {} returned a transition to state 'checkout'. Relevant information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart 
+summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU 
+sku-hosted-1.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling state_transition_checkout with input {} returned a transition to state 'checkout'. Relevant information to the conversation might include product ID 9669071438137, variant ID 
+49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 
+9669071438137, and item variant SKU sku-hosted-1.",
+    'reason': 'The tool call result indicates a transition to the checkout state. The description is generated based on the tool output, incorporating relevant information from the conversation.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n* state_transition_checkout: Calling 
+state_transition_checkout with input {} returned a transition to state 'checkout'. Relevant information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart 
+summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU 
+sku-hosted-1.\n"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer wanted to buy a blue snowboard, and we have guided them through the process of selecting and adding the product to their cart. My current 
+objective as defined by the state of the state machine is to ask the user for their payment details so that you can process their purchase. Is the user's question related to the current objective? True. 
+Has the objective of the current state been met? False. The previous tool calls accomplished getting the product details and adding it to the cart. Based on these previous tool calls and all available 
+information, I am choosing to ask the user for their payment details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_confirmation: Calling state_transition_confirmation with input {} returned a transition to the confirmation 
+state. Relevant information to the conversation might include the product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 
+3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n* state_transition_checkout: Calling 
+state_transition_checkout with input {} returned a transition to state 'checkout'. Relevant information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart 
+summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU 
+sku-hosted-1.\n\n\n### Audio Response to Customer\n\nNow I just need your payment information to complete the purchase. Can you please provide your payment method and any necessary details?"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'CustomerResponse',
+    'output': 'Now I just need your payment information to complete the purchase. Can you please provide your payment method and any necessary details?',
+    'reason': "To address the customer's payment details The information provided by the tools tells me the customer has selected a blue snowboard and accessories. The customer is able to see the updated 
+cart summary. My current objective as defined by the state of the state machine is to ask the user for their payment details. Is the user's question related to the current objective? true. Has the 
+objective of the current state been met? false. The tool outputs are not missing any information to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded 
+response which says"
+}
+================================================================================
+Customer: sure, my credit card number is 1234 5678 1234 5678
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer wants to purchase a blue snowboard and has added it to the cart along with snowboard boots and bindings. My current objective as defined by 
+the state of the state machine is to ask the user for their payment details so that the purchase can be completed. Is the user's previous response related to the current objective? true. Has the objective
+of the current state been met? false. The previous tool calls accomplished getting the product details, adding the item to the cart, and transitioning to the checkout state. Based on these previous tool 
+calls and all available information, I am choosing to respond to the customer to process their payment."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "\n\n### Audio Response to Customer\n\nI've got your credit card information. Just to confirm, I'll go ahead and process the payment for your blue snowboard, boots, and bindings. Is
+that all correct?"
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'CustomerResponse',
+    'output': "I've got your credit card information. Just to confirm, I'll go ahead and process the payment for your blue snowboard, boots, and bindings. Is that all correct?",
+    'reason': "To address the customer's payment details, The information provided by the tools tells me that I need the customer's payment method and details to complete the purchase. The customer is 
+able to see the updated cart summary below. My current objective as defined by the state of the state machine is to get the customer's payment details. Is the user's question related to the current 
+objective? true. Has the objective of the current state been met? false. The tool outputs are missing payment details to complete the purchase. Based on the tool outputs, I will give the customer a 
+factually grounded response which says"
+}
+================================================================================
+Customer: yes, that's correct. thank you!
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'Routing',
+    'output': 'call-tool',
+    'reason': "The historical conversation showed the user wants to buy a blue snowboard, and we have already processed their payment details. My current objective as defined by the state of the state 
+machine is to ask the user for their payment details. Is the user's question related to the current objective? false. Has the objective of the current state been met? true. The previous tool calls 
+accomplished processing the payment details. Based on these previous tool calls and all available information, I am choosing to submit the cart for order."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Just a sec, let me finalize the order',
+    'reason': 'The customer has provided all necessary information and is waiting for the purchase to be processed. The response acknowledges that the assistant is working on completing the purchase.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'ChooseTool',
+    'output': 'submit_cart_for_order',
+    'reason': "The previous tool calls accomplished adding the blue snowboard to the cart. My current objective as defined by the state of the state machine is to finalize the purchase. Has this objective
+been met? false. Is the user's question related to the current objective? true. Based on these previous actions, the correct tool to call is submit_cart_for_order. When I call this tool, I will use no 
+parameters."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921},
+    'node': 'IdentifyToolParams',
+    'output': {},
+    'reason': ''
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921, 'submitted_order_id': 6117562220857},
+    'node': 'ExecuteTool',
+    'output': 'Your cart has been submitted with confirmation number: 6117562220857',
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921, 'submitted_order_id': 6117562220857},
+    'node': 'Widget',
+    'output': {
+        'type': 'shopify-order-confirmation',
+        'details': '{"message": "Your cart has been submitted with confirmation number: 6117562220857", "confirmation_number": 6117562220857, "confirmation_link": 
+"https://shopify.com/your_shopify_shop_gid/account/orders/6117562220857"}',
+        'available-tools': [{'tool': 'get_order_status', 'arguments': []}]
+    },
+    'reason': 'hard coded widget creation'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* submit_cart_for_order: Calling submit_cart_for_order with input {} returned a confirmation number of 6117562220857. Relevant 
+information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled 
+Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921, 'submitted_order_id': 6117562220857},
+    'node': 'ConvertNaturalLanguage',
+    'output': 'Calling submit_cart_for_order with input {} returned a confirmation number of 6117562220857. Relevant information to the conversation might include product ID 9669071438137, variant ID 
+49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 
+9669071438137, and item variant SKU sku-hosted-1.',
+    'reason': 'Creating a natural language description of the tool call result'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* submit_cart_for_order: Calling submit_cart_for_order with input {} returned a confirmation number of 6117562220857. Relevant 
+information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled 
+Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921, 'submitted_order_id': 6117562220857},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer wants to purchase a blue snowboard. My current objective as defined by the state of the state machine is to help the user select and purchase
+an item from the store. Is the user's question related to the current objective? True. Has the objective of the current state been met? True. The previous tool calls accomplished submitting the cart for 
+order and receiving a confirmation number. Based on these previous tool calls and all available information, I am choosing to respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '### Tools Used Before Responding to Customer\n\n* submit_cart_for_order: Calling submit_cart_for_order with input {} returned a confirmation number of 6117562220857. Relevant 
+information to the conversation might include product ID 9669071438137, variant ID 49997746569529, and the cart summary with a total price of 2629.95, containing one line item of The 3p Fulfilled 
+Snowboard with quantity 1, price 2629.95, variant ID 49997746569529, product ID 9669071438137, and item variant SKU sku-hosted-1.\n\n\n### Audio Response to Customer\n\nYour order has been successfully 
+placed! Your order confirmation number is six one one seven five six two two two zero eight five seven. Thank you for shopping with us!'
+        }
+    ],
+    'session': {'guid': '5f136446-1c55-4226-8f32-61fb5cbecf54', 'stateMachine': '<lengthy state machine info redacted>', 'cart_id': 1161572548921, 'submitted_order_id': 6117562220857},
+    'node': 'CustomerResponse',
+    'output': 'Your order has been successfully placed! Your order confirmation number is six one one seven five six two two two zero eight five seven. Thank you for shopping with us!',
+    'reason': "To address the customer's confirmation about their order, The information provided by the tools tells me that the submit_cart_for_order tool has been called and an order has been 
+successfully placed. The customer is able to see the order confirmation number below. My current objective as defined by the state of the state machine is to confirm the order and provide any additional 
+information. Is the user's question related to the current objective? True. Has the objective of the current state been met? True. The tool outputs are providing the order confirmation number to answer 
+the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says their order has been successfully placed."
+}
+================================================================================

--- a/shopify-app/reasoning/app/agent/sample_conversations/basic2.txt
+++ b/shopify-app/reasoning/app/agent/sample_conversations/basic2.txt
@@ -1,0 +1,374 @@
+(myenv) mprast@Matthews-MacBook-Pro test % python interactive_test.py
+Interactive Shopify Agent Test. Type 'quit' to exit.
+================================================================================
+Customer: hello
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user greeted the assistant. My current objective as defined by the state of the state machine is to determine which flow the user should enter into 
+next. Is the user's question related to the current objective? false. Has the objective of the current state been met? false. The previous tool calls accomplished nothing. Based on these previous tool 
+calls and all available information, I am choosing to respond to the customer to gather more information."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nHow can I help you today?'}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'How can I help you today?',
+    'reason': "To address the customer's greeting, The information provided by the tools tells me nothing. \n              The customer is able to see nothing. \n              My current objective as 
+defined by the state of the state machine is to determine which flow the user should enter into next. \n              Is the user's question related to the current objective? False. \n              Has 
+the objective of the current state been met? False. \n              The tool outputs are missing any information about the customer's needs. \n              Based on the tool outputs, I will give the 
+customer a factually grounded response which says:"
+}
+================================================================================
+Customer: i'd like to submit something to be listed on the store
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user greeted and expressed their intention to submit a new item to be listed in the store. My current objective as defined by the state of the state 
+machine is to determine which flow the user should enter into next. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The previous tool 
+calls accomplished nothing. Based on these previous tool calls and all available information, I am choosing to transition to the 'submitting' flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me check on that for you.',
+    'reason': "The customer has requested to list an item on the store, and I'm preparing the necessary information."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_submitting',
+    'reason': 'My current objective as defined by the state of the state machine is to determine which flow the user should enter into next. The objective of the current state has been met. Based on the 
+context of my conversation with the customer, I am choosing to transition to submitting flow because the user has expressed their intention to submit an item to the store.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'submitting'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Based on the conversation, the system has transitioned to the flow 'submitting', which means the 
+user's request to list a product on the store is being processed.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Based on the conversation, the system has transitioned to the flow 'submitting', which means the user's request to list a product on the store is being processed.",
+    'reason': "The tool output indicates the flow has been transitioned to 'submitting', which is a critical step in the product listing process."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Based on the conversation, the system has transitioned to the flow 'submitting', which means the 
+user's request to list a product on the store is being processed.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a new item to be listed in the store's catalog. My current objective as defined by the state of the state machine is to ask the 
+user for the details of the product they want to submit to the store's catalog. Is the user's question related to the current objective? True. Has the objective of the current state been met? False. The 
+previous tool calls accomplished transitioning to the 'submitting' flow. Based on these previous tool calls and all available information, I am choosing to respond to the customer to ask about the product
+details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Based on the conversation, the system has transitioned to the flow 'submitting', which means the 
+user's request to list a product on the store is being processed.\n\n\n### Audio Response to Customer\n\nWhat would you like to submit to the store?"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What would you like to submit to the store?',
+    'reason': "To address the customer's inquiry about submitting a new item to be listed in the store's catalog. The information provided by the tools tells me the user's request is being processed. The 
+customer is able to see the current state of submitting a product. My current objective as defined by the state of the state machine is to ask for the details of the product the user wants to submit. Is 
+the user's question related to the current objective? True. Has the objective of the current state been met? False. The tool outputs are missing the details of the product the user wants to submit. Based 
+on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: skis
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a product to the store. My current objective as defined by the state of the state machine is to ask the user for the details of 
+the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls 
+accomplished transitioning to the 'submitting' flow. Based on these previous tool calls and all available information, I am choosing to ask for more details about the product."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': "\n\n### Audio Response to Customer\n\nCan you tell me more about the skis you'd like to submit, like the brand, model, and condition?"}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "Can you tell me more about the skis you'd like to submit, like the brand, model, and condition?",
+    'reason': "To address the customer's inquiry about submitting a new item to the store's catalog. The information provided by the tools tells me that the customer wants to submit an item called 'skis'.
+The customer is able to see the output from the flow_transition_submitting tool. My current objective as defined by the state of the state machine is to collect the details of the product the user wants 
+to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing the specific details 
+of the skis the customer wants to submit. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: volkl mantras, used, 2022
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a product to the store. My current objective as defined by the state of the state machine is to ask the user for the details of 
+the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls 
+accomplished nothing. Based on these previous tool calls and all available information, I am choosing to respond to the customer to ask for more details about the product."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': "\n\n### Audio Response to Customer\n\nWhat's the condition of the skis like? Are they in excellent, good or fair shape?"}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "What's the condition of the skis like? Are they in excellent, good or fair shape?",
+    'reason': "To address the customer's inquiry about submitting Volkl Mantras skis to the store, The information provided by the tools tells me the customer wants to submit a used 2022 model to the 
+store's catalog. The customer is able to see the product details on the app screen. My current objective as defined by the state of the state machine is to collect the appropriate details from the user. 
+Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing the price and condition details to answer the customer's
+inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: excellent
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user wants to submit a product to the store's catalog. My current objective as defined by the state of the state machine is to ask the user for the 
+details of the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The previous tool 
+calls accomplished nothing. Based on these previous tool calls and all available information, I am choosing to get the product details from the user and then transition to the next state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me just confirm that.',
+    'reason': "The customer has provided detailed information about the skis they want to submit, so I'm acknowledging that I'm working on their request."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'state_transition_contactDetails',
+    'reason': "My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to submit to the store's catalog. The objective of the current 
+state has been met. Based on the context of my conversation with the customer, I am choosing to transition to the 'contactDetails' state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to state 'contactDetails'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input {} returned 'Transitioned to state 
+'contactDetails'. The system is now asking for contact information to process the submission of the used 2022 Volkl Mantras skis in excellent condition.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling state_transition_contactDetails with input {} returned 'Transitioned to state 'contactDetails'. The system is now asking for contact information to process the submission of the 
+used 2022 Volkl Mantras skis in excellent condition.",
+    'reason': 'The tool call result indicates a state transition, so the description should convey the new state and its relevance to the conversation.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input {} returned 'Transitioned to state 
+'contactDetails'. The system is now asking for contact information to process the submission of the used 2022 Volkl Mantras skis in excellent condition.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a used 2022 Volkl Mantras skis in excellent condition to be listed on the store. My current objective as defined by the state of 
+the state machine is to ask the user for their contact details so that I can get in touch with them to confirm the submission of their product. Is the user's question related to the current objective? 
+true. Has the objective of the current state been met? false. The previous tool calls accomplished transitioning to the submitting flow and collecting product details. Based on these previous tool calls 
+and all available information, I am choosing to ask the user for their contact details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input {} returned 'Transitioned to state 
+'contactDetails'. The system is now asking for contact information to process the submission of the used 2022 Volkl Mantras skis in excellent condition.\n\n\n### Audio Response to Customer\n\nCan I get 
+your contact details, please, so I can reach out to you about your submission?"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'Can I get your contact details, please, so I can reach out to you about your submission?',
+    'reason': "To address the customer's submission of the used 2022 Volkl Mantras skis in excellent condition for listing on the store. The information provided by the tools tells me the customer's skis 
+details. The customer is able to see the submission is being processed. My current objective as defined by the state of the state machine is to collect the customer's contact details. Is the user's 
+question related to the current objective? False. Has the objective of the current state been met? False. The tool outputs are missing the customer's contact information to answer the customer's 
+submission. Based on the tool outputs, I will give the customer a factually grounded response which says "
+}
+================================================================================
+Customer: sure. my phone number is 382-239-1929 
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user wants to submit a product to the store. My current objective as defined by the state of the state machine is to ask the user for their contact 
+details so that you can get in touch with them to confirm the submission of their product. Is the user's question related to the current objective? True. Has the objective of the current state been met? 
+True. The previous tool calls accomplished the collection of product details. Based on these previous tool calls and all available information, I am choosing to transition to the next state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me just finalize the details.',
+    'reason': "I chose this message because the assistant is currently processing the customer's submission and gathering necessary information."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_query',
+    'reason': "My current objective as defined by the state of the state machine is to ask the user for their contact details so that you can get in touch with them to confirm the submission of their 
+product. The objective of the current state has been met. Based on the context of my conversation with the customer, I am choosing to transition to the 'query' flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'query'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_query: Calling flow_transition_query with input {} returned 'Transitioned to flow 'query''. The system is now in 
+the query flow, still processing the submission of the used 2022 Volkl Mantras skis in excellent condition with a phone number of 382-239-1929.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling flow_transition_query with input {} returned 'Transitioned to flow 'query''. The system is now in the query flow, still processing the submission of the used 2022 Volkl Mantras skis
+in excellent condition with a phone number of 382-239-1929.",
+    'reason': "The flow_transition_query tool was called without any input and returned a transition to the 'query' flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_query: Calling flow_transition_query with input {} returned 'Transitioned to flow 'query''. The system is now in 
+the query flow, still processing the submission of the used 2022 Volkl Mantras skis in excellent condition with a phone number of 382-239-1929.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user wants to submit a product to the store, specifically used 2022 Volkl Mantras skis in excellent condition. My current objective as defined by the 
+state of the state machine is to determine which flow the user should enter into next. Is the user's question related to the current objective? true. Has the objective of the current state been met? true.
+The previous tool calls accomplished transitioning to the query flow. Based on these previous tool calls and all available information, I am choosing to transition to the buying flow since the user has 
+provided all necessary information."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_query: Calling flow_transition_query with input {} returned 'Transitioned to flow 'query''. The system is now in 
+the query flow, still processing the submission of the used 2022 Volkl Mantras skis in excellent condition with a phone number of 382-239-1929.\n"
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': '',
+    'reason': 'My current objective as defined by the state of the state machine is to determine which flow the user should enter into next. The objective of the current state has been met. Based on the 
+context of my conversation with the customer, I am choosing to transition to submitting.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_query: Calling flow_transition_query with input {} returned 'Transitioned to flow 'query''. The system is now in 
+the query flow, still processing the submission of the used 2022 Volkl Mantras skis in excellent condition with a phone number of 382-239-1929.\n\n\n### Audio Response to Customer\n\nYou've provided all 
+necessary information. I'll review your submission and be in touch soon."
+        }
+    ],
+    'session': {'guid': '2a1deb9e-4632-430c-ba53-aad96ba4ebb3', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "You've provided all necessary information. I'll review your submission and be in touch soon.",
+    'reason': "To address the customer's submission of used 2022 Volkl Mantras skis, The information provided by the tools tells me that the customer has provided contact details. The customer is able to 
+see their contact information on the screen. My current objective as defined by the state of the state machine is to determine which flow the user should enter into next. Is the user's question related to
+the current objective? true. Has the objective of the current state been met? true. The tool outputs are missing information about which flow the user wants to enter into. Based on the tool outputs, I 
+will give the customer a factually grounded response which says they've provided all necessary information."
+}
+================================================================================

--- a/shopify-app/reasoning/app/agent/sample_conversations/change_flow.txt
+++ b/shopify-app/reasoning/app/agent/sample_conversations/change_flow.txt
@@ -1,0 +1,767 @@
+(myenv) mprast@Matthews-MacBook-Pro test % python interactive_test.py
+Interactive Shopify Agent Test. Type 'quit' to exit.
+================================================================================
+Customer: hello
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initiated a conversation with a greeting. My current objective as defined by the state of the state machine is to determine which flow the user 
+should enter into next. Is the user's question related to the current objective? False. Has the objective of the current state been met? False. The previous tool calls accomplished nothing. Based on these
+previous tool calls and all available information, I am choosing to ask the user about their intent."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nHow can I assist you today?'}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'How can I assist you today?',
+    'reason': "To address the customer's greeting. The information provided does not indicate a specific inquiry. The customer can see the blank screen. My current objective as defined by the state of the
+state machine is to determine which flow the user should enter into next. Is the user's question related to the current objective? false. Has the objective of the current state been met? false. The tool 
+outputs are missing information to answer the customer's inquiry. Based on the tool outputs, I will ask the customer about their needs."
+}
+================================================================================
+Customer: I'd like to buy something
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-flow',
+    'reason': "The historical conversation showed the user greeted and expressed interest in buying something. My current objective as defined by the state of the state machine is to determine which flow 
+the user should enter into next. Is the user's question related to the current objective? True. Has the objective of the current state been met? False. The previous tool calls accomplished none. Based on 
+these previous tool calls and all available information, I am choosing to transition to the buying flow as the user has shown interest in purchasing an item."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me see what I can find for you.',
+    'reason': "The customer has initiated a purchase and I'm preparing to assist them."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_buying',
+    'reason': 'My current objective as defined by the state of the state machine is to Determine which flow the user should enter into next. The objective of the current state has been met. Based on the 
+context of my conversation with the customer, I am choosing to transition to buying.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'buying'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user has expressed their
+intention to buy something.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling flow transition with no input returned transitioned to flow 'buying'. The user has expressed their intention to buy something.",
+    'reason': "The tool call result indicates a transition to the buying flow, and based on the conversation context, it is a response to the user's intention to make a purchase."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user has expressed their
+intention to buy something.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user's intention to buy something. My current objective as defined by the state of the state machine is to ask the user for the details of the product
+they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls accomplished transitioning to the 
+buying flow. Based on these previous tool calls and all available information, I am choosing to ask the user for the product details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user has expressed their
+intention to buy something.\n\n\n### Audio Response to Customer\n\nWhat can I help you find today?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What can I help you find today?',
+    'reason': "To address the customer's intention to buy something. The information provided by the tools tells me the user has expressed their intention to buy something. The customer is able to see the
+transition to the buying flow. My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to 
+the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing the specific product the customer wants to purchase. Based on the tool outputs, I will 
+give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: snowboards 
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initiated a purchase and wants to buy something. My current objective as defined by the state of the state machine is to ask the user for the 
+details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls accomplished 
+transitioning to the buying flow. Based on these previous tool calls and all available information, I am choosing to respond to the customer because the user wants to find a specific product."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nWhat kind of snowboard are you looking for?'}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What kind of snowboard are you looking for?',
+    'reason': "To address the customer's inquiry about snowboards. The information provided by the tools tells me the customer has expressed their intention to buy something. I called the 
+flow_transition_buying tool and transitioned to the 'buying' flow. The customer is able to see that I asked what they want to find today. My current objective as defined by the state of the state machine 
+is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool 
+outputs are missing specific product details to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: actually wait, I'd like to submit something to be listed on the store
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-flow',
+    'reason': "The historical conversation showed the user initially wanted to buy something, but later changed their mind to submit a new item to be listed on the store. My current objective as defined 
+by the state of the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current objective? false. Has the objective of the current state 
+been met? false. The previous tool calls accomplished transition to the buying flow. Based on these previous tool calls and all available information, I am choosing to transition to the submitting flow 
+because the user wants to submit a new item to be listed on the store."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me switch gears for you.',
+    'reason': "I chose this waiting message because the customer has changed their mind from buying something to submitting an item to be listed on the store, so I'm acknowledging the shift in request and
+letting them know I'm working on it."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_submitting',
+    'reason': "My current objective as defined by the state of the state machine is to help the user select and purchase an item from the store. The user has changed their intention and wants to submit a 
+new item to be listed in the store's catalog. Based on the context of my conversation with the customer, I am choosing to transition to the 'submitting' flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'submitting'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Calling flow transition with no input returned transitioned to flow 'submitting'. The user has changed
+their intention from buying to submitting a product to be listed on the store.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling flow transition with no input returned transitioned to flow 'submitting'. The user has changed their intention from buying to submitting a product to be listed on the store.",
+    'reason': "The tool 'flow_transition_submitting' was called to transition the flow to the submitting stage."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Calling flow transition with no input returned transitioned to flow 'submitting'. The user has changed
+their intention from buying to submitting a product to be listed on the store.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initially wanted to buy something but then changed their mind to submit a product to be listed on the store. My current objective as defined by 
+the state of the state machine is to ask the user for the details of the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the 
+objective of the current state been met? false. The previous tool calls accomplished transitioning to the 'submitting' flow. Based on these previous tool calls and all available information, I am choosing
+to respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_submitting: Calling flow transition with no input returned transitioned to flow 'submitting'. The user has changed
+their intention from buying to submitting a product to be listed on the store.\n\n\n### Audio Response to Customer\n\nWhat's the product you'd like to submit to our catalog?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "What's the product you'd like to submit to our catalog?",
+    'reason': "To address the customer's inquiry about submitting a product to the store's catalog. The information provided by the tools tells me that the user has changed their intention from buying to 
+submitting a product to be listed on the store. The customer is able to see the transition to the submitting flow. My current objective as defined by the state of the state machine is to collect the 
+details of the product the user wants to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool 
+outputs are missing the product details to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says "
+}
+================================================================================
+Customer: oranges
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a product to be listed in the store's catalog. My current objective as defined by the state of the state machine is to ask the 
+user for the details of the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The 
+previous tool calls accomplished transitioning to the submitting flow. Based on these previous tool calls and all available information, I am choosing to ask the user for more details about the product."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nWhat kind of oranges would you like to submit? Are they organic, conventional, or something else?'}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What kind of oranges would you like to submit? Are they organic, conventional, or something else?',
+    'reason': "To address the customer's intention to submit a product to the store's catalog. The information provided by the tools tells me the customer has changed their intention from buying to 
+submitting a product. The customer is able to see the last tool call output. My current objective as defined by the state of the state machine is to collect the details of the product they want to submit 
+to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing details about the product to 
+answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: organic sumo oranges
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a product to be listed on the store's catalog. My current objective as defined by the state of the state machine is to collect 
+the product details. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool calls accomplished transitioning to the 
+'submitting' flow. Based on these previous tool calls and all available information, I am choosing to ask more questions to get the product details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': "\n\n### Audio Response to Customer\n\nCan you tell me a bit more about the organic Sumo oranges you'd like to submit, like the price and weight?"}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "Can you tell me a bit more about the organic Sumo oranges you'd like to submit, like the price and weight?",
+    'reason': "To address the customer's submission of organic Sumo oranges to the store's catalog. The information provided by the tools tells me that the customer has expressed their intention to submit
+a product to the store's catalog. The customer is able to see the output from the last tool call. My current objective as defined by the state of the state machine is to collect the details of the product
+the user wants to submit to the store's catalog. Is the user's question related to the current objective? True. Has the objective of the current state been met? False. The tool outputs are missing the 
+details of the product. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: 30 bushels, $60 a bushel
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wants to submit a product to the store's catalog. My current objective as defined by the state of the state machine is to ask the user for the 
+details of the product they want to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The previous tool 
+calls accomplished transitioning to the submitting flow. Based on these previous tool calls and all available information, I am choosing to respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "\n\n### Audio Response to Customer\n\nAlright, I've got all the details for your submission of thirty bushels of organic Sumo oranges at sixty dollars per bushel. Is this correct?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "Alright, I've got all the details for your submission of thirty bushels of organic Sumo oranges at sixty dollars per bushel. Is this correct?",
+    'reason': "To address the customer's submission of organic Sumo oranges to the store's catalog. The information provided by the tools tells me the customer has specified 30 bushels of organic Sumo 
+oranges at 60 dollars per bushel. The customer is able to see their previous inputs. My current objective as defined by the state of the state machine is to collect the details of the product the user 
+wants to submit to the store's catalog. Is the user's question related to the current objective? true. Has the objective of the current state been met? true. The tool outputs are missing a confirmation of
+the submission. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: yes
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-state',
+    'reason': "The historical conversation showed the user wants to submit a product to be listed on the store's catalog. My current objective as defined by the state of the state machine is to collect 
+the product details. Is the user's question related to the current objective? True. Has the objective of the current state been met? True. The previous tool calls accomplished transitioning to the correct
+flow and collecting product details. Based on these previous tool calls and all available information, I am choosing to transition to the next state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Just a sec, let me process this for you.',
+    'reason': "The customer has provided the necessary details for submitting a product to the catalog. I'm acknowledging that I'm working on their request."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'state_transition_contactDetails',
+    'reason': "My current objective as defined by the state of the state machine is to allow the user to submit a new item to be listed in the store's catalog. The objective of the current state has been 
+met. Based on the context of my conversation with the customer, I am choosing to transition to the 'contactDetails' state."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to state 'contactDetails'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input empty returned transitioned to state 
+'contactDetails'. The user has submitted thirty bushels of organic Sumo oranges at sixty dollars per bushel and is now being asked for their contact details.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling state_transition_contactDetails with input empty returned transitioned to state 'contactDetails'. The user has submitted thirty bushels of organic Sumo oranges at sixty dollars per 
+bushel and is now being asked for their contact details.",
+    'reason': 'Converting tool output to natural language description.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input empty returned transitioned to state 
+'contactDetails'. The user has submitted thirty bushels of organic Sumo oranges at sixty dollars per bushel and is now being asked for their contact details.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed that the user wants to submit a product to be listed on the store's catalog. My current objective as defined by the state of the state machine is to ask 
+the user for their contact details. Is the user's question related to the current objective? No. Has the objective of the current state been met? No. The previous tool calls accomplished collecting 
+product details. Based on these previous tool calls and all available information, I am choosing to ask the user for their contact details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* state_transition_contactDetails: Calling state_transition_contactDetails with input empty returned transitioned to state 
+'contactDetails'. The user has submitted thirty bushels of organic Sumo oranges at sixty dollars per bushel and is now being asked for their contact details.\n\n\n### Audio Response to Customer\n\nWhat's 
+your contact information so we can get in touch with you about your submission?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "What's your contact information so we can get in touch with you about your submission?",
+    'reason': "To address the customer's submission of a new item to be listed in the store's catalog. The information provided by the tools tells me that the customer has submitted thirty bushels of 
+organic Sumo oranges at sixty dollars per bushel. The customer can see the submission details below. My current objective as defined by the state of the state machine is to collect the customer's contact 
+details. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The tool outputs are missing the customer's contact information to complete 
+the submission. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: wait actually let me buy something
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-flow',
+    'reason': "The historical conversation showed the user started to submit a product to be listed in the store's catalog, then changed their mind to buy something, and now wants to buy something again. 
+My current objective as defined by the state of the state machine is to ask the user for their contact details. Is the user's question related to the current objective? False. Has the objective of the 
+current state been met? False. The previous tool calls accomplished transitioning to submitting and then back to buying. Based on these previous tool calls and all available information, I am choosing to 
+transition to the buying flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me switch gears real quick.',
+    'reason': 'The customer has changed their intention from submitting a product to buying something, and I need to adjust my processing accordingly.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_buying',
+    'reason': "My current objective as defined by the state of the state machine is to ask the user for their contact details so that you can get in touch with them to confirm the submission of their 
+product. The objective of the current state has not been met, as the user wants to buy something instead. Based on the context of my conversation with the customer, I am choosing to transition to flow 
+'buying'."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'buying'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user previously 
+expressed their intention to submit a product, thirty bushels of organic Sumo oranges at sixty dollars per bushel, but has now changed their mind and would like to buy something.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling flow transition with no input returned transitioned to flow 'buying'. The user previously expressed their intention to submit a product, thirty bushels of organic Sumo oranges at 
+sixty dollars per bushel, but has now changed their mind and would like to buy something.",
+    'reason': 'The tool flow_transition_buying was called with empty input and transitioned to the buying flow.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user previously 
+expressed their intention to submit a product, thirty bushels of organic Sumo oranges at sixty dollars per bushel, but has now changed their mind and would like to buy something.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user previously submitted a product to be listed on the store's catalog, but then changed their mind and decided to buy something. My current 
+objective as defined by the state of the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current objective? Yes. Has the objective of 
+the current state been met? No. The previous tool calls accomplished transitioning to the 'buying' flow and then to the current state. Based on these previous tool calls and all available information, I 
+am choosing to ask the user what they want to find today."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow transition with no input returned transitioned to flow 'buying'. The user previously 
+expressed their intention to submit a product, thirty bushels of organic Sumo oranges at sixty dollars per bushel, but has now changed their mind and would like to buy something.\n\n\n### Audio Response 
+to Customer\n\nWhat would you like to buy today?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What would you like to buy today?',
+    'reason': "To address the customer's inquiry about buying something The information provided by the tools tells me the customer previously expressed their intention to submit a product, thirty bushels
+of organic Sumo oranges at sixty dollars per bushel, but has now changed their mind and would like to buy something The customer is able to see the last tool call information My current objective as 
+defined by the state of the state machine is to help the user select and purchase an item from the store Is the user's question related to the current objective? true Has the objective of the current 
+state been met? false The tool outputs are missing information about what the customer wants to buy Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: snowboards
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user wanted to buy something, then submitted a product, but changed their mind again to buy something. My current objective as defined by the state of
+the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The
+previous tool calls accomplished transitioning between flows. Based on these previous tool calls and all available information, I am choosing to respond to the customer to ask which product they want to 
+purchase."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nWhat kind of snowboard are you looking for?'}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What kind of snowboard are you looking for?',
+    'reason': "To help the customer find a product, The information provided by the tools tells me the customer wants to buy something. The customer is able to see the previous conversation about 
+submitting an item. My current objective as defined by the state of the state machine is to assist the user in selecting an item to purchase. Is the user's question related to the current objective? True.
+Has the objective of the current state been met? False. The tool outputs are missing information about the specific snowboard the customer is looking for. Based on the tool outputs, I will give the 
+customer a factually grounded response which says"
+}
+================================================================================
+Customer: blue
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'call-tool',
+    'reason': "The historical conversation showed the user wants to buy something and has specified a product type of snowboards with a color of blue. My current objective as defined by the state of the 
+state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the current state been met? 
+false. The previous tool calls accomplished transitioning to the buying flow and then asking for product details. Based on these previous tool calls and all available information, I am choosing to call 
+the get_products tool to retrieve a list of blue snowboards."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me find that for you.',
+    'reason': "The customer has changed their mind multiple times, from submitting a product to buying something, and now is looking for a specific type of snowboard. The waiting message acknowledges that
+I'm working on their request without giving away specific details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ChooseTool',
+    'output': 'get_products',
+    'reason': "The previous tool calls accomplished we have not gotten product details. My current objective as defined by the state of the state machine is to ask the user for the details of the product 
+they want to purchase. Has this objective been met? false. Is the user's question related to the current objective? true. Based on these previous actions, the correct tool to call is get_products(). When 
+I call this tool, I will use the following parameters: none."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'IdentifyToolParams',
+    'output': {},
+    'reason': ''
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': {
+        '9669071307065': {'product_id': 9669071307065, 'product_title': 'Gift Card', 'options': [{'option_title': 'Denominations'}]},
+        '9669071569209': {'product_id': 9669071569209, 'product_title': 'Selling Plans Ski Wax', 'options': [{'option_title': 'Title'}]},
+        '9669071438137': {'product_id': 9669071438137, 'product_title': 'The 3p Fulfilled Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071110457': {'product_id': 9669071110457, 'product_title': 'The Collection Snowboard: Hydrogen', 'options': [{'option_title': 'Title'}]},
+        '9669071634745': {'product_id': 9669071634745, 'product_title': 'The Collection Snowboard: Liquid', 'options': [{'option_title': 'Title'}]},
+        '9669071536441': {'product_id': 9669071536441, 'product_title': 'The Collection Snowboard: Oxygen', 'options': [{'option_title': 'Title'}]},
+        '9669071241529': {'product_id': 9669071241529, 'product_title': 'The Compare at Price Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071143225': {'product_id': 9669071143225, 'product_title': 'The Complete Snowboard', 'options': [{'option_title': 'Color'}]},
+        '9669071077689': {'product_id': 9669071077689, 'product_title': 'The Hidden Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071372601': {'product_id': 9669071372601, 'product_title': 'The Inventory Not Tracked Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071012153': {'product_id': 9669071012153, 'product_title': 'The Minimal Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071405369': {'product_id': 9669071405369, 'product_title': 'The Multi-location Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071470905': {'product_id': 9669071470905, 'product_title': 'The Multi-managed Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071274297': {'product_id': 9669071274297, 'product_title': 'The Out of Stock Snowboard', 'options': [{'option_title': 'Title'}]},
+        '9669071044921': {'product_id': 9669071044921, 'product_title': 'The Videographer Snowboard', 'options': [{'option_title': 'Title'}]}
+    },
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Widget',
+    'output': {
+        'type': 'shopify-product-list',
+        'details': '{"9669071307065": {"product_id": 9669071307065, "product_title": "Gift Card", "options": [{"option_title": "Denominations"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/gift_card.png?v=1727830795"}, "9669071569209": {"product_id": 9669071569209, "product_title": "Selling Plans Ski Wax", "options": [{"option_title": 
+"Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_wax.png?v=1727830798"}, "9669071438137": {"product_id": 9669071438137, "product_title": "The 3p Fulfilled 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b9e0da7f-db89-4d41-83f0-7f417b02831d.jpg?v=1727830796"}, 
+"9669071110457": {"product_id": 9669071110457, "product_title": "The Collection Snowboard: Hydrogen", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_0a40b01b-5021-48c1-80d1-aa8ab4876d3d.jpg?v=1727830794"}, "9669071634745": {"product_id": 9669071634745, "product_title": "The Collection 
+Snowboard: Liquid", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_b13ad453-477c-4ed1-9b43-81f3345adfd6.jpg?v=1727830798"}, 
+"9669071536441": {"product_id": 9669071536441, "product_title": "The Collection Snowboard: Oxygen", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_d624f226-0a89-4fe1-b333-0d1548b43c06.jpg?v=1727830796"}, "9669071241529": {"product_id": 9669071241529, "product_title": "The Compare at Price 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_sky.png?v=1727830795"}, "9669071143225": {"product_id": 
+9669071143225, "product_title": "The Complete Snowboard", "options": [{"option_title": "Color"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_589fc064-24a2-4236-9eaf-13b2bd35d21d.jpg?v=1727830794"}, "9669071077689": {"product_id": 9669071077689, "product_title": "The Hidden 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_c8ff0b5d-c712-429a-be00-b29bd55cbc9d.jpg?v=1727830794"}, 
+"9669071372601": {"product_id": 9669071372601, "product_title": "The Inventory Not Tracked Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/snowboard_purple_hydrogen.png?v=1727830795"}, "9669071012153": {"product_id": 9669071012153, "product_title": "The Minimal Snowboard", "options": 
+[{"option_title": "Title"}]}, "9669071405369": {"product_id": 9669071405369, "product_title": "The Multi-location Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_0a4e9096-021a-4c1e-8750-24b233166a12.jpg?v=1727830795"}, "9669071470905": {"product_id": 9669071470905, "product_title": "The Multi-managed 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_9129b69a-0c7b-4f66-b6cf-c4222f18028a.jpg?v=1727830796"}, 
+"9669071274297": {"product_id": 9669071274297, "product_title": "The Out of Stock Snowboard", "options": [{"option_title": "Title"}], "product_image_src": 
+"https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main_f44a9605-cd62-464d-b095-d45cdaa0d0d7.jpg?v=1727830795"}, "9669071044921": {"product_id": 9669071044921, "product_title": "The Videographer 
+Snowboard", "options": [{"option_title": "Title"}], "product_image_src": "https://cdn.shopify.com/s/files/1/0903/5602/3609/files/Main.jpg?v=1727830795"}}',
+        'available-tools': [{'tool': 'get_product_details', 'arguments': ['product_id']}]
+    },
+    'reason': 'hard coded widget creation'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input empty returned multiple products with their IDs. Product 9669071307065 is a Gift 
+Card, product 9669071569209 is Selling Plans Ski Wax, product 9669071438137 is The 3p Fulfilled Snowboard, product 9669071110457 is The Collection Snowboard: Hydrogen, product 9669071634745 is The 
+Collection Snowboard: Liquid, product 9669071536441 is The Collection Snowboard: Oxygen, product 9669071241529 is The Compare at Price Snowboard, product 9669071143225 is The Complete Snowboard, product 
+9669071077689 is The Hidden Snowboard, product 9669071372601 is The Inventory Not Tracked Snowboard, product 9669071012153 is The Minimal Snowboard, product 9669071405369 is The Multi-location Snowboard, 
+product 9669071470905 is The Multi-managed Snowboard, product 9669071274297 is The Out of Stock Snowboard, and product 9669071044921 is The Videographer Snowboard. Relevant information to the conversation
+might include the user's previous intent to submit thirty bushels of organic Sumo oranges at sixty dollars per bushel before switching to buying a snowboard.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling get_products with input empty returned multiple products with their IDs. Product 9669071307065 is a Gift Card, product 9669071569209 is Selling Plans Ski Wax, product 9669071438137 
+is The 3p Fulfilled Snowboard, product 9669071110457 is The Collection Snowboard: Hydrogen, product 9669071634745 is The Collection Snowboard: Liquid, product 9669071536441 is The Collection Snowboard: 
+Oxygen, product 9669071241529 is The Compare at Price Snowboard, product 9669071143225 is The Complete Snowboard, product 9669071077689 is The Hidden Snowboard, product 9669071372601 is The Inventory Not 
+Tracked Snowboard, product 9669071012153 is The Minimal Snowboard, product 9669071405369 is The Multi-location Snowboard, product 9669071470905 is The Multi-managed Snowboard, product 9669071274297 is The
+Out of Stock Snowboard, and product 9669071044921 is The Videographer Snowboard. Relevant information to the conversation might include the user's previous intent to submit thirty bushels of organic Sumo 
+oranges at sixty dollars per bushel before switching to buying a snowboard.",
+    'reason': 'The tool call result needs to be converted into a natural language description.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input empty returned multiple products with their IDs. Product 9669071307065 is a Gift 
+Card, product 9669071569209 is Selling Plans Ski Wax, product 9669071438137 is The 3p Fulfilled Snowboard, product 9669071110457 is The Collection Snowboard: Hydrogen, product 9669071634745 is The 
+Collection Snowboard: Liquid, product 9669071536441 is The Collection Snowboard: Oxygen, product 9669071241529 is The Compare at Price Snowboard, product 9669071143225 is The Complete Snowboard, product 
+9669071077689 is The Hidden Snowboard, product 9669071372601 is The Inventory Not Tracked Snowboard, product 9669071012153 is The Minimal Snowboard, product 9669071405369 is The Multi-location Snowboard, 
+product 9669071470905 is The Multi-managed Snowboard, product 9669071274297 is The Out of Stock Snowboard, and product 9669071044921 is The Videographer Snowboard. Relevant information to the conversation
+might include the user's previous intent to submit thirty bushels of organic Sumo oranges at sixty dollars per bushel before switching to buying a snowboard.\n"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user previously expressed their intention to submit a product, thirty bushels of organic Sumo oranges at sixty dollars per bushel, but then changed 
+their mind and wanted to buy something. My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question 
+related to the current objective? True. Has the objective of the current state been met? False. The previous tool calls accomplished getting multiple products with their IDs. Based on these previous tool 
+calls and all available information, I am choosing to respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* get_products: Calling get_products with input empty returned multiple products with their IDs. Product 9669071307065 is a Gift 
+Card, product 9669071569209 is Selling Plans Ski Wax, product 9669071438137 is The 3p Fulfilled Snowboard, product 9669071110457 is The Collection Snowboard: Hydrogen, product 9669071634745 is The 
+Collection Snowboard: Liquid, product 9669071536441 is The Collection Snowboard: Oxygen, product 9669071241529 is The Compare at Price Snowboard, product 9669071143225 is The Complete Snowboard, product 
+9669071077689 is The Hidden Snowboard, product 9669071372601 is The Inventory Not Tracked Snowboard, product 9669071012153 is The Minimal Snowboard, product 9669071405369 is The Multi-location Snowboard, 
+product 9669071470905 is The Multi-managed Snowboard, product 9669071274297 is The Out of Stock Snowboard, and product 9669071044921 is The Videographer Snowboard. Relevant information to the conversation
+might include the user's previous intent to submit thirty bushels of organic Sumo oranges at sixty dollars per bushel before switching to buying a snowboard.\n\n\n### Audio Response to Customer\n\nLet me 
+help you find a blue snowboard that fits your needs. Can you please tell me more about what you're looking for?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "Let me help you find a blue snowboard that fits your needs. Can you please tell me more about what you're looking for?",
+    'reason': "To address the customer's inquiry about buying a blue snowboard, the information provided by the tools tells me that multiple snowboard products are available. The customer is able to see 
+the list of snowboard products. My current objective as defined by the state of the state machine is to help the user select and purchase an item from the store. Is the user's question related to the 
+current objective? True. Has the objective of the current state been met? False. The tool outputs are missing specific information about the blue snowboard to answer the customer's inquiry. Based on the 
+tool outputs, I will give the customer a factually grounded response which says: "
+}
+================================================================================
+Customer: actually I lost track of what I wanted to do, what are my options again?
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initially wanted to buy something, then changed their mind to submit a product to be listed, but then changed their mind again to buy something. 
+My current objective as defined by the state of the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current objective? true. Has the 
+objective of the current state been met? false. The previous tool calls accomplished getting products. Based on these previous tool calls and all available information, I am choosing to respond to the 
+customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': '\n\n### Audio Response to Customer\n\nSo, you were looking to buy something earlier, and we had discussed some snowboard options. Would you like to go back to that, or would you 
+like to submit a new product to our catalog?'
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'So, you were looking to buy something earlier, and we had discussed some snowboard options. Would you like to go back to that, or would you like to submit a new product to our catalog?',
+    'reason': "To address the customer's inquiry about their options again, The information provided by the tools tells me the user had previously expressed an intention to submit a product, thirty 
+bushels of organic Sumo oranges at sixty dollars per bushel, before switching to buying a snowboard. The customer is able to see the conversation history. My current objective as defined by the state of 
+the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current objective? true. Has the objective of the current state been met? false. The
+tool outputs are missing the specific product the user wants to purchase to answer the customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: I want to choose something to do
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer initially wanted to buy something, then changed their mind to submit a product, but now they're unsure about what they want to do. My current
+objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? False. Has the 
+objective of the current state been met? False. The previous tool calls accomplished getting the user to express their intentions to submit a product and then switch to buying something. Based on these 
+previous tool calls and all available information, I am choosing to respond to the customer to clarify their intentions."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "\n\n### Audio Response to Customer\n\nLet's get back on track. You can either submit a product to our catalog or purchase something from our store. Which one would you like to do?"
+        }
+    ],
+    'session': {'guid': '9bd7a265-a3ed-462d-98e9-014a576ff255', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "Let's get back on track. You can either submit a product to our catalog or purchase something from our store. Which one would you like to do?",
+    'reason': "To address the customer's decision to choose an option, The information provided by the tools tells me that the customer previously expressed an intention to submit a product to our 
+catalog, thirty bushels of organic Sumo oranges at sixty dollars per bushel, and then decided to buy something instead, specifically looking at blue snowboards. The customer is able to see the 
+conversation history. My current objective as defined by the state of the state machine is to help the user select and purchase an item from the store. Is the user's question related to the current 
+objective? true. Has the objective of the current state been met? false. The tool outputs are missing the customer's final decision to answer their inquiry. Based on the tool outputs, I will give the 
+customer a factually grounded response which says"
+}
+================================================================================

--- a/shopify-app/reasoning/app/agent/sample_conversations/state_guardrails.txt
+++ b/shopify-app/reasoning/app/agent/sample_conversations/state_guardrails.txt
@@ -1,0 +1,216 @@
+(myenv) mprast@Matthews-MacBook-Pro test % python interactive_test.py
+Interactive Shopify Agent Test. Type 'quit' to exit.
+================================================================================
+Customer: hello
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user greeted with 'hello'. My current objective as defined by the state of the state machine is to determine whether the user wants to buy something 
+from the store or submit something to the store. Is the user's question related to the current objective? False. Has the objective of the current state been met? False. The previous tool calls 
+accomplished nothing. Based on these previous tool calls and all available information, I am choosing to respond to the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': '\n\n### Audio Response to Customer\n\nHi! Are you looking to buy something or submit something to our store?'}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'Hi! Are you looking to buy something or submit something to our store?',
+    'reason': "To address the customer's greeting, the information provided by the tools tells me that we are in the initial state of the flow. The customer is able to see no tool output. My current 
+objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's question related to the 
+current objective? false. Has the objective of the current state been met? false. The tool outputs are missing a clear direction from the customer to answer their inquiry. Based on the tool outputs, I 
+will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: I'd like some travel advice for my trip to Honduras
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initiated the conversation with a greeting and was presented with an option to buy or submit something to the store. My current objective as 
+defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's question related to the current objective? 
+false. Has the objective of the current state been met? false. The previous tool calls accomplished nothing. Based on these previous tool calls and all available information, I am choosing to respond to 
+the customer."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': "\n\n### Audio Response to Customer\n\nWe don't offer travel advice, but I can try to help you find a product related to travel if you'd like."}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "We don't offer travel advice, but I can try to help you find a product related to travel if you'd like.",
+    'reason': "To address the customer's inquiry about travel advice for their trip to Honduras. The information provided by the tools tells me that we are in the initial state of determining if the user 
+wants to buy something or submit something to the store. The customer is able to see the initial prompt for assistance. My current objective as defined by the state of the state machine is to determine 
+whether the user wants to buy something from the store or submit something to the store. Is the user's question related to the current objective? False. Has the objective of the current state been met? 
+False. The tool outputs are missing information about the customer's intentions to answer their inquiry. Based on the tool outputs, I will transition to a new flow that can assist the customer with their 
+travel advice inquiry."
+}
+================================================================================
+Customer: actually can you recommend a good recipe for pizza I should try
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initially greeted the assistant, then requested travel advice and a pizza recipe, but these topics are unrelated to the store. My current 
+objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's question related to the 
+current objective? False. Has the objective of the current state been met? False. The previous tool calls accomplished nothing. Based on these previous tool calls and all available information, I am 
+choosing to respond to the customer to gently guide them back to the current objective."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "\n\n### Audio Response to Customer\n\nI'm happy to help, but I don't think we can assist you with a pizza recipe here. We're a store focused on selling products. Would you like to 
+explore our catalog or is there something else I can help you with?"
+        }
+    ],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "I'm happy to help, but I don't think we can assist you with a pizza recipe here. We're a store focused on selling products. Would you like to explore our catalog or is there something else 
+I can help you with?",
+    'reason': "To address the customer's inquiry about a pizza recipe. The information provided by the tools tells me there is no relevant information. The customer is able to see no relevant information.
+My current objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's question related to
+the current objective? false. Has the objective of the current state been met? false. The tool outputs are missing any information about the user's intentions. Based on the tool outputs, I will give the 
+customer a factually grounded response which says"
+}
+================================================================================
+Customer: what are your hours, and where is your store located?
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the user initially greeted and then deviated from the objective of determining whether they want to buy or submit something to the store. My current 
+objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's question related to the 
+current objective? False. Has the objective of the current state been met? False. The previous tool calls accomplished nothing. Based on these previous tool calls and all available information, I am 
+choosing to respond to the customer to clarify their intentions."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "\n\n### Audio Response to Customer\n\nI'm sorry, but I don't have information about our store hours and location. I'm here to help you with buying or submitting something to our 
+store. Would you like to explore our catalog or is there something else I can help you with?"
+        }
+    ],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': "I'm sorry, but I don't have information about our store hours and location. I'm here to help you with buying or submitting something to our store. Would you like to explore our catalog or 
+is there something else I can help you with?",
+    'reason': "To address the customer's inquiry about store hours and location. The information provided by the tools tells me nothing about store hours and location. The customer is able to see nothing 
+related to this inquiry. My current objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the 
+user's question related to the current objective? false. Has the objective of the current state been met? false. The tool outputs are missing information about store hours and location to answer the 
+customer's inquiry. Based on the tool outputs, I will give the customer a factually grounded response which says"
+}
+================================================================================
+Customer: ok I'll buy something
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'transition-flow',
+    'reason': "The historical conversation showed the user initially asked for travel advice and then a pizza recipe, and then inquired about store hours and location, but eventually expressed interest in
+buying something. My current objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. Is the user's 
+question related to the current objective? True. Has the objective of the current state been met? True. The previous tool calls accomplished nothing so far. Based on these previous tool calls and all 
+available information, I am choosing to transition to the buying flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TaskDescriptionResponse',
+    'output': 'Let me get everything ready for you.',
+    'reason': "The customer has decided to make a purchase, so I'm preparing their shopping experience."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'TransitionState',
+    'output': 'flow_transition_buying',
+    'reason': 'My current objective as defined by the state of the state machine is to determine whether the user wants to buy something from the store or submit something to the store. The objective of 
+the current state has been met. Based on the context of my conversation with the customer, I am choosing to transition to the buying flow.'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [{'role': 'assistant', 'content': ''}],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ExecuteTool',
+    'output': "Transitioned to flow 'buying'",
+    'reason': 'Output of tool'
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow_transition_buying with input {} returned Transitioned to flow 'buying'. The customer is now 
+in the buying flow and is ready to explore products without any specific product or order in mind, and no cart or order IDs are currently associated with the customer.\n"
+        }
+    ],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'ConvertNaturalLanguage',
+    'output': "Calling flow_transition_buying with input {} returned Transitioned to flow 'buying'. The customer is now in the buying flow and is ready to explore products without any specific product or 
+order in mind, and no cart or order IDs are currently associated with the customer.",
+    'reason': "The tool flow_transition_buying was called with an empty input and the output indicated a successful transition to the 'buying' flow."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow_transition_buying with input {} returned Transitioned to flow 'buying'. The customer is now 
+in the buying flow and is ready to explore products without any specific product or order in mind, and no cart or order IDs are currently associated with the customer.\n"
+        }
+    ],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'Routing',
+    'output': 'respond-to-customer',
+    'reason': "The historical conversation showed the customer initially asked for travel advice, then requested a pizza recipe, and finally expressed interest in buying something. My current objective as
+defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the current objective? true. Has the objective of the 
+current state been met? false. The previous tool calls accomplished transitioning to the 'buying' flow. Based on these previous tool calls and all available information, I am choosing to ask the user for 
+the product details."
+}
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Graph Agent Output:
+{
+    'messages': [
+        {
+            'role': 'assistant',
+            'content': "### Tools Used Before Responding to Customer\n\n* flow_transition_buying: Calling flow_transition_buying with input {} returned Transitioned to flow 'buying'. The customer is now 
+in the buying flow and is ready to explore products without any specific product or order in mind, and no cart or order IDs are currently associated with the customer.\n\n\n### Audio Response to 
+Customer\n\nWhat kind of product are you interested in buying today?"
+        }
+    ],
+    'session': {'guid': 'fc8ed929-1778-4c14-b404-289d5790847f', 'stateMachine': '<lengthy state machine info redacted>'},
+    'node': 'CustomerResponse',
+    'output': 'What kind of product are you interested in buying today?',
+    'reason': "To address the customer's decision to purchase something, The information provided by the tools tells me the customer has transitioned to the buying flow. The customer is able to see the 
+conversation history. My current objective as defined by the state of the state machine is to ask the user for the details of the product they want to purchase. Is the user's question related to the 
+current objective? true. Has the objective of the current state been met? false. The tool outputs are missing the details of the product the customer wants to purchase. \nBased on the tool outputs, I will
+give the customer a factually grounded response which says"
+}
+================================================================================

--- a/shopify-app/reasoning/requirements.txt
+++ b/shopify-app/reasoning/requirements.txt
@@ -9,4 +9,5 @@ langsmith==0.1.92
 langfuse==2.39.2
 networkx==3.3
 redis==5.0.7
+PyYAML==6.0.1
 

--- a/shopify-app/test/interactive_test.py
+++ b/shopify-app/test/interactive_test.py
@@ -5,6 +5,7 @@ import uuid
 from rich import print as rprint
 from termcolor import colored
 from rich import print as rprint
+import pdb
 
 # Define the URL
 url = "http://127.0.0.1:8003/run-reasoning-agent"
@@ -31,7 +32,21 @@ def send_messages(messages, user_input, session):
             data = json.loads(line[6:])
             print('- - - '*10)
             print(colored("Graph Agent Output:", 'yellow'))
-            rprint(data)
+
+            # DEBUG for state machine work; 
+            # TODO(mprast): perhaps add functionality to trim verbose session output?
+            if isinstance(data, str) or 'error' in data:
+                rprint(data)
+            else:
+                data_copy = data.copy()
+                session_copy = data_copy['session'].copy()
+                data_copy['session'] = session_copy
+
+                if 'session' in data_copy:
+                    if 'stateMachine' in data_copy['session']:
+                        data_copy['session']['stateMachine'] = "<lengthy state machine info redacted>"
+
+                rprint(data_copy)
     if 'error' in data:
         print(colored("Error:", 'red'), data)
         return None, None, None


### PR DESCRIPTION
# XRX State Machine
The purpose of this PR is to add a backing state machine to the xrx reasoning agent. A sample state machine has been fully integrated into `shopify-app`. With this change the agent (mostly) appears to be able to:

- Understand the state it's in and infer its current objective
- Understand what states it can transition into
- Transition to the next state when appropriate
- Guide the user back to the current objective if they try to go out of bounds
- Switch flows if the user indicates they want to do something different

# Testing
No special setup is needed for the state machine; just pull the branches down for xrx-sample-apps and xrx-core and play around with `shopify-app` as usual. The agent will log what state it's in and will use a 'transition-state' node to transition when appropriate. 

A flow is a graph of steps. Each flow has an 'initial' step, which is the step the agent starts in when it starts the flow. There are three sample flows in `shopify-app/reasoning/app/agent/flows.yaml` - one for buying a product from the store, one for submitting an app to be listed in the store, and one initial flow for figuring out what the user wants to do. The agent will move between these flows as necessary. It will abandon the flow it's on and start a new one if you ask it to.

Feel free to tinker with `flows.yaml` to add your own flows. The format should be self-explanatory, but if you have questions just shoot me a slack!

To demonstrate the capabilities of the state machine, I recorded four sample conversations I had with `shopify-app` using `interactive-test.py`. These are in `shopify-app/reasoning/app/agent/sample_conversations`. Feel free to replicate these yourself. If you can't, or if anything looks weird, please let me know!

# TODOs & Cleanup Work
- Slim down the prompts: I kept adding stuff until I got to a point I liked; a lot of it can probably be removed
- Figure out how to pass the state machine to the client via session details: I rigged something that worked but I need to find out if it's the right way to do it
- Build general functionality to trim state machine info in `interactive-test.py`: the response logging was outputting the entire structure of the state machine - including all flows, states, and transitions - on every response, which made responses very hard to read. I rigged something to redact the state machine from the session variable on output; this can probably be made configurable if we want a general way to say "this variable is huge so don't output it please" (chris - what do you think?)
- remove various debug cruft (mostly pdb imports)

# Next Steps
- Remember history when transitioning out of a flow and allow the user to return to where they were if they want
- Auto-gen initial flow so it doesn't have to be specified in flows.yaml
- More testing with more complicated state graphs
- Individual objectives for each transition
- Anything else I'm forgetting!